### PR TITLE
ci: adopt shared review governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Purpose
+
+Describe the visitor outcome and the narrow scope of this change.
+
+## Published-truth boundary
+
+- [ ] Claims match approved Skratsch source material.
+- [ ] Routes, redirects, canonical URLs, and sitemap effects are explicit.
+- [ ] Images, downloads, and other static assets resolve correctly.
+- [ ] Accessibility and responsive behavior were checked where relevant.
+
+## Verification
+
+- [ ] `npm run verify` passes, or limitations are explicit.
+- [ ] Preview or deployment implications are explicit.
+- [ ] Rollback is documented.
+
+## Authority boundary
+
+Passing checks and review evidence do not grant merge, publication, deployment,
+spending, communications, or production-mutation authority.
+
+## Author handoff
+
+- [ ] Branch is current with `main`.
+- [ ] Validation evidence is attached.
+- [ ] Positive and single-fault negative fixtures cover the change.
+- [ ] Notion is updated where material.
+- [ ] `needs-independent-review` is applied.
+- [ ] Passing checks are not treated as merge or operational authority.
+
+<!-- skratsch-author-handoff:v1
+{"headSha":"FULL_HEAD_SHA","branchCurrent":false,"validationEvidenceAttached":false,"singleFaultFixturesCovered":false,"notionUpdated":false,"independentReviewRequested":false,"noAuthorityClaim":false}
+-->
+
+## Selected review attestation
+
+After posting the authenticated maintainer attestation, replace `0` with its
+numeric GitHub comment ID. Only that selected comment is evaluated.
+
+<!-- skratsch-review-selection:v1
+{"headSha":"FULL_HEAD_SHA","attestationCommentId":0}
+-->
+
+Each lane disposition must be exactly `ACCEPT`, `RETURN INCOMPLETE`, or
+`BLOCKED`, with an HTTPS, exact-host, non-root evidence record.

--- a/.github/workflows/review-readiness.yml
+++ b/.github/workflows/review-readiness.yml
@@ -1,0 +1,26 @@
+name: Review packet readiness
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, labeled, unlabeled, ready_for_review]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  review-packet:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Verify SHA-bound solo-maintainer review packet
+        uses: skratsch-solutions/.github/actions/solo-review@6db8120e97ec31b5e98002e5ef4319aa4c104d56
+        with:
+          github-token: ${{ github.token }}
+          maintainer-user-ids: '[98485953]'
+          evidence-hosts: '["app.notion.com"]'
+          max-api-pages: '20'

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,18 @@
+# Governance
+
+## Published truth
+
+The public website presents approved Skratsch claims. Product positioning,
+capabilities, status, links, and evidence must remain traceable to approved
+source material. A successful build does not by itself authorize publication.
+
+## Solo-maintainer review packet
+
+Pull requests use separate semantic and authority/security review functions,
+followed by an authenticated maintainer attestation bound to the exact head SHA.
+The organization-owned validator is pinned by full commit SHA and runs with
+read-only permissions without checking out pull-request code.
+
+This model separates review functions but does not claim multiple human
+principals. Passing review is evidence only; the maintainer retains the separate
+merge, publication, deployment, and operational authority decisions.


### PR DESCRIPTION
## Purpose

Adopt the organization-wide exact-SHA review-readiness workflow for the public Skratsch website, together with its published-truth review template and governance boundary.

## Scope

- Add the pinned shared review-readiness caller.
- Add website-specific review prompts for claims, routes, assets, accessibility, preview, and rollback.
- Document solo-maintainer authority limits and independent-review evidence requirements.

## Verification

- npm ci passed: 303 packages, 0 vulnerabilities.
- npm run verify passed.
- Astro check: 0 errors, 0 warnings, 6 pre-existing non-blocking hints.
- Static build: 51 pages.
- Route parity: 50 preserved legacy URLs.
- Static asset audit: 53 image/font URLs.
- git diff --check passed.

## Evidence and bootstrap note

Review packet: https://app.notion.com/p/3cfc44b38aff818295eff31a5bb4a977?pvs=204

The new pull_request_target workflow cannot validate its own adoption PR because GitHub uses the workflow definition from the base branch. It becomes active after merge.

## Authority boundary

Passing checks and solo-maintainer acceptance do not constitute independent review and do not grant publication, deployment, spending, communications, or other production-mutation authority.

<!-- skratsch-author-handoff:v1
{"headSha":"753ac8ca0d8efdc46d8da537229db295d2933380","branchCurrent":true,"validationEvidenceAttached":true,"singleFaultFixturesCovered":true,"notionUpdated":true,"independentReviewRequested":true,"noAuthorityClaim":true}
-->

<!-- skratsch-review-selection:v1
{"headSha":"753ac8ca0d8efdc46d8da537229db295d2933380","attestationCommentId":5517353299}
-->
